### PR TITLE
Fix command namespace removal in tab completion

### DIFF
--- a/src/main/java/de/elia/cameraplugin/camfly/CameraPlugin.java
+++ b/src/main/java/de/elia/cameraplugin/camfly/CameraPlugin.java
@@ -588,7 +588,11 @@ public final class CameraPlugin extends JavaPlugin implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void filterCommandSuggestions(PlayerCommandSendEvent event) {
-        event.getCommands().removeIf(cmd -> cmd.equalsIgnoreCase("camplugin:cam"));
+        // Remove the namespaced variant of our command from the suggestion list
+        // so only "/cam" is shown when tab completing. Using the plugin name
+        // ensures this works even if the plugin is renamed.
+        String namespaced = getName().toLowerCase() + ":cam";
+        event.getCommands().removeIf(cmd -> cmd.equalsIgnoreCase(namespaced));
     }
 
     @EventHandler


### PR DESCRIPTION
## Summary
- ensure `PlayerCommandSendEvent` removes the namespaced command using the plugin name

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eccfa213083228cedd7d220925ca0