### PR TITLE
Fix body movement and attack message

### DIFF
--- a/src/main/java/de/elia/cameraplugin/camfly/CameraPlugin.java
+++ b/src/main/java/de/elia/cameraplugin/camfly/CameraPlugin.java
@@ -212,6 +212,7 @@ public final class CameraPlugin extends JavaPlugin implements Listener {
         hitboxEntities.put(hitbox.getUniqueId(), player.getUniqueId());
 
         startHitboxSync(armorStand, hitbox);
+        startArmorStandHealthCheck(player, armorStand);
         addPlayerToNoCollisionTeam(player);
         updateViewerTeam(player);
         updateVisibilityForAll();
@@ -618,6 +619,9 @@ public final class CameraPlugin extends JavaPlugin implements Listener {
         // Cancel attacks on anything except the player's own armor stand or hitbox
         if (ownerUUID == null || !ownerUUID.equals(attacker.getUniqueId())) {
             event.setCancelled(true);
+            if (ownerUUID != null && !ownerUUID.equals(attacker.getUniqueId())) {
+                attacker.sendMessage(getMessage("cant-attack-other-body"));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- detect armor stand movement and stop camera mode with `body-moved` message
- notify players when trying to attack another player's body

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686ed4db6b8883228538d3a8025acaea