### PR TITLE
Fix lightning transformation bug

### DIFF
--- a/src/main/java/de/elia/cameraplugin/camfly/CameraPlugin.java
+++ b/src/main/java/de/elia/cameraplugin/camfly/CameraPlugin.java
@@ -385,7 +385,11 @@ public final class CameraPlugin extends JavaPlugin implements Listener {
 
         String messageKey = event instanceof EntityDamageByEntityEvent ?
                 "body-attacked" : "body-env-damage";
-        owner.sendMessage(getMessage(messageKey).replace("{damager}", damagerName));
+        owner.sendMessage(
+                getMessage(messageKey)
+                        .replace("{damager}", damagerName)
+                        .replace("{cause}", event.getCause().toString())
+        );
         pendingDamage.remove(ownerUUID);
     }
 
@@ -409,6 +413,15 @@ public final class CameraPlugin extends JavaPlugin implements Listener {
                     player.sendMessage(getMessage("cant-interact-other"));
                 }
             }
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onHitboxTransform(EntityTransformEvent event) {
+        if (event.getTransformReason() == EntityTransformEvent.TransformReason.LIGHTNING
+                && event.getEntity() instanceof Villager villager
+                && hitboxEntities.containsKey(villager.getUniqueId())) {
+            event.setCancelled(true);
         }
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,7 +5,7 @@ messages:
   no-player: "&cDieser Befehl kann nur von Spielern verwendet werden."
   distance-limit: "&cDu kannst dich nicht weiter als {distance} Blöcke von deinem Körper entfernen!"
   body-attacked: "&cDein Körper wurde von {damager} angegriffen! Kamera-Modus beendet."
-  body-env-damage: "&cDein Körper wurde durch Umweltschaden verletzt! Kamera-Modus beendet."
+  body-env-damage: "&cDein Körper wurde durch {cause} verletzt! Kamera-Modus beendet."
   body-moved: "&cDein Körper wurde bewegt! Kamera-Modus beendet."
   cant-fly-in-lava: "&cDu kannst nicht durch Lava fliegen! Kamera-Modus wird beendet."
   cant-interact-other: "&cDu kannst mit dem Körper eines anderen Spielers nicht interagieren!"


### PR DESCRIPTION
## Summary
- show damage cause in `body-env-damage` message
- cancel villager-to-witch transformation from lightning strikes

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686edcabe2a88322975fe2cd19a17e9a